### PR TITLE
Update asmdef files to remove define constraints

### DIFF
--- a/Unity-Package/Assets/root/Tests/Editor/com.IvanMurzak.Unity.MCP.Animation.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/com.IvanMurzak.Unity.MCP.Animation.Editor.Tests.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "com.IvanMurzak.Unity.MCP.Animation.Editor.Tests",
+    "rootNamespace": "",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
@@ -28,9 +29,7 @@
         "R3.dll"
     ],
     "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
+    "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Unity-Package/Assets/root/Tests/Runtime/com.IvanMurzak.Unity.MCP.Animation.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Runtime/com.IvanMurzak.Unity.MCP.Animation.Tests.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "com.IvanMurzak.Unity.MCP.Animation.Tests",
+    "rootNamespace": "",
     "references": [
         "UnityEngine.TestRunner",
         "com.IvanMurzak.Unity.MCP.Runtime",
@@ -23,9 +24,7 @@
         "R3.dll"
     ],
     "autoReferenced": false,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
+    "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Removed the UNITY_INCLUDE_TESTS define constraint and set rootNamespace to an empty string in both Editor and Runtime test assembly definition files. This streamlines test assembly configuration and may improve compatibility with certain build setups.