### PR TITLE
feat: add MCP tool hint annotations (ReadOnlyHint, DestructiveHint)

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.GetData.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.GetData.cs
@@ -28,7 +28,8 @@ namespace com.IvanMurzak.Unity.MCP.Animation
         [McpPluginTool
         (
             AnimationGetDataToolId,
-            Title = "Animation / Get Data"
+            Title = "Animation / Get Data",
+            ReadOnlyHint = true
         )]
         [Description(@"Get data about a Unity AnimationClip asset file. Returns information such as name, length, frame rate, wrap mode, animation curves, and events.")]
         public static GetDataResponse GetData

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Modify.cs
@@ -29,7 +29,8 @@ namespace com.IvanMurzak.Unity.MCP.Animation
         [McpPluginTool
         (
             AnimationModifyToolId,
-            Title = "Animation / Modify"
+            Title = "Animation / Modify",
+            DestructiveHint = true
         )]
         [Description("Modify Unity's AnimationClip asset. " +
             "Apply an array of modifications including setting curves, clearing curves, setting properties, and managing animation events. " +

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.GetData.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.GetData.cs
@@ -27,7 +27,8 @@ namespace com.IvanMurzak.Unity.MCP.Animation
         [McpPluginTool
         (
             AnimatorGetDataToolId,
-            Title = "Animator / Get Data"
+            Title = "Animator / Get Data",
+            ReadOnlyHint = true
         )]
         [Description(@"Get data about a Unity AnimatorController asset file. Returns information such as name, layers, parameters, and states.")]
         public static GetAnimatorDataResponse GetData

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Modify.cs
@@ -31,7 +31,8 @@ namespace com.IvanMurzak.Unity.MCP.Animation
         [McpPluginTool
         (
             AnimatorModifyToolId,
-            Title = "Animator / Modify"
+            Title = "Animator / Modify",
+            DestructiveHint = true
         )]
         [Description("Modify Unity's AnimatorController asset. " +
             "Apply an array of modifications including adding/removing parameters, layers, states, and transitions. " +


### PR DESCRIPTION
Adds `McpPluginTool` hint annotations to all applicable MCP tools based on their behavior:

- `animation-get-data`: `ReadOnlyHint = true`
- `animation-modify`: `DestructiveHint = true`
- `animator-get-data`: `ReadOnlyHint = true`
- `animator-modify`: `DestructiveHint = true`

Closes #6

Generated with [Claude Code](https://claude.ai/code)