### PR TITLE
Add workflow to bump version with GitHub Actions

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,51 @@
+name: bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version number (e.g. 1.2.3)"
+        required: true
+        type: string
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ github.event.inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: version must be in X.X.X format (got: ${{ github.event.inputs.version }})"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release branch
+        run: |
+          git config user.name "IvanMurzak"
+          git config user.email "Ivan.D.Murzak@gmail.com"
+          git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Run bump-version script
+        shell: pwsh
+        run: ./commands/bump-version.ps1 -NewVersion "${{ github.event.inputs.version }}"
+
+      - name: Commit and push version bump
+        run: |
+          git add -A
+          git commit -m "chore: bump version to ${{ github.event.inputs.version }}"
+          git push origin release/${{ github.event.inputs.version }}
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base ${{ github.ref_name }} \
+            --head release/${{ github.event.inputs.version }} \
+            --title "chore: bump version to ${{ github.event.inputs.version }}" \
+            --body "Automated version bump to \`${{ github.event.inputs.version }}\` triggered via workflow dispatch."


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the version bump process. The workflow allows maintainers to trigger a version bump by providing a new version number, validates the input, creates a release branch, runs the version bump script, commits the changes, and opens a pull request.

Automation of version bump process:

* Added `.github/workflows/bump_version.yml` workflow that enables maintainers to trigger a version bump via workflow dispatch with a specified version number, validates the version format, creates a release branch, runs the `bump-version.ps1` script, commits and pushes changes, and automatically opens a pull request for the version bump.