### PR TITLE
Update test asmdefs, package version & settings

### DIFF
--- a/Unity-Package/Assets/root/Tests/Editor/com.IvanMurzak.Unity.MCP.Animation.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/com.IvanMurzak.Unity.MCP.Animation.Editor.Tests.asmdef
@@ -2,8 +2,6 @@
     "name": "com.IvanMurzak.Unity.MCP.Animation.Editor.Tests",
     "rootNamespace": "",
     "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
         "com.IvanMurzak.Unity.MCP.Editor",
         "com.IvanMurzak.Unity.MCP.Editor.Tests",
         "com.IvanMurzak.Unity.MCP.Runtime",
@@ -15,10 +13,10 @@
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "System.Text.Json.dll",
         "Microsoft.Extensions.Logging.Abstractions.dll",
         "Microsoft.AspNetCore.SignalR.Client.dll",
@@ -29,7 +27,9 @@
         "R3.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Unity-Package/Assets/root/Tests/Runtime/com.IvanMurzak.Unity.MCP.Animation.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Runtime/com.IvanMurzak.Unity.MCP.Animation.Tests.asmdef
@@ -2,7 +2,6 @@
     "name": "com.IvanMurzak.Unity.MCP.Animation.Tests",
     "rootNamespace": "",
     "references": [
-        "UnityEngine.TestRunner",
         "com.IvanMurzak.Unity.MCP.Runtime",
         "com.IvanMurzak.Unity.MCP.Tests",
         "com.IvanMurzak.Unity.MCP.TestFiles",
@@ -10,10 +9,10 @@
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "System.Text.Json.dll",
         "Microsoft.Extensions.Logging.Abstractions.dll",
         "Microsoft.AspNetCore.SignalR.Client.dll",

--- a/Unity-Package/Packages/packages-lock.json
+++ b/Unity-Package/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ivanmurzak.unity.mcp": {
-      "version": "0.51.4",
+      "version": "0.51.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Unity-Package/ProjectSettings/ProjectSettings.asset
+++ b/Unity-Package/ProjectSettings/ProjectSettings.asset
@@ -80,7 +80,7 @@ PlayerSettings:
   androidPredictiveBackSupport: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0

--- a/Unity-Tests/2022.3.62f3/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/2022.3.62f3/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2022.3.62f3/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/2022.3.62f3/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2022.3.62f3/Packages/manifest.json
+++ b/Unity-Tests/2022.3.62f3/Packages/manifest.json
@@ -44,5 +44,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["com.ivanmurzak.unity.mcp.animation"]
 }

--- a/Unity-Tests/2023.2.22f1/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/2023.2.22f1/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2023.2.22f1/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/2023.2.22f1/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2023.2.22f1/Packages/manifest.json
+++ b/Unity-Tests/2023.2.22f1/Packages/manifest.json
@@ -47,5 +47,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["com.ivanmurzak.unity.mcp.animation"]
 }

--- a/Unity-Tests/6000.3.1f1/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/6000.3.1f1/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/6000.3.1f1/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/6000.3.1f1/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/6000.3.1f1/Packages/manifest.json
+++ b/Unity-Tests/6000.3.1f1/Packages/manifest.json
@@ -48,5 +48,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["com.ivanmurzak.unity.mcp.animation"]
 }


### PR DESCRIPTION
Enable Unity test assembly configuration and adjust project settings across test projects.

- Removed explicit UnityEngine.TestRunner/UnityEditor.TestRunner references and nunit.framework precompiled entries from test asmdef files.
- Added optionalUnityReferences: ["TestAssemblies"] and defineConstraints: ["UNITY_INCLUDE_TESTS"] so test assemblies compile/resolve correctly.
- Added "testables": ["com.ivanmurzak.unity.mcp.animation"] to test manifests so the package is exposed to test projects.
- Bumped package version in packages-lock.json from 0.51.4 to 0.51.5.
- Enabled PlayerSettings.runInBackground in ProjectSettings.

Changes apply to the package and Unity-Tests folders for 2022.3, 2023.2 and 6000.3.1f1 test setups.