### PR TITLE
ci: add disk cleanup step to CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Cache Unity Library
         uses: actions/cache@v5
         with:

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -56,7 +56,20 @@ jobs:
           lfs: false
 
       # --------------------------------------------------------------------- #
-      # 2-c. Cache & run the Unity test-runner
+      # 2-c. Free disk space
+      # --------------------------------------------------------------------- #
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      # --------------------------------------------------------------------- #
+      # 2-d. Cache & run the Unity test-runner
       # --------------------------------------------------------------------- #
       - uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Summary
- Add `jlumbroso/free-disk-space@v1.3.1` step to `test_unity_plugin.yml` (between checkout and cache steps)
- Add `jlumbroso/free-disk-space@v1.3.1` step to `release.yml` `build-unity-installer` job (after checkout, before cache)
- Frees disk space by removing Android, .NET, Haskell, large packages, and swap storage before Unity runs

Closes #18

## Test plan
- [ ] Verify `test_unity_plugin.yml` workflow runs successfully with the new step
- [ ] Verify `release.yml` `build-unity-installer` job runs successfully with the new step
- [ ] Confirm disk space is freed before Unity test/build steps execute
- [ ] Ensure no regressions in existing CI test matrix (editmode, playmode, standalone across all Unity versions)