### PR TITLE
fix(deps): adopt AIGD namespace for Unity-MCP 0.68.0

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.GetData.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.GetData.cs
@@ -15,7 +15,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Modify.cs
@@ -16,7 +16,7 @@ using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEngine;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.GetData.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.GetData.cs
@@ -15,7 +15,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor.Animations;
 

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Modify.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using UnityEditor;
 using UnityEditor.Animations;

--- a/Unity-Package/Assets/root/Tests/Editor/AnimationGetData_Tests.cs
+++ b/Unity-Package/Assets/root/Tests/Editor/AnimationGetData_Tests.cs
@@ -14,7 +14,7 @@ using System;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 
 namespace com.IvanMurzak.Unity.MCP.Animation.Editor.Tests
 {

--- a/Unity-Package/Assets/root/Tests/Editor/AnimationModify_Tests.cs
+++ b/Unity-Package/Assets/root/Tests/Editor/AnimationModify_Tests.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using com.IvanMurzak.McpPlugin;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 
 namespace com.IvanMurzak.Unity.MCP.Animation.Editor.Tests
 {

--- a/Unity-Package/Assets/root/Tests/Editor/AnimatorGetData_Tests.cs
+++ b/Unity-Package/Assets/root/Tests/Editor/AnimatorGetData_Tests.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 
 namespace com.IvanMurzak.Unity.MCP.Animation.Editor.Tests
 {

--- a/Unity-Package/Assets/root/Tests/Editor/AnimatorModify_Tests.cs
+++ b/Unity-Package/Assets/root/Tests/Editor/AnimatorModify_Tests.cs
@@ -17,7 +17,7 @@ using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
 using com.IvanMurzak.McpPlugin;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 
 namespace com.IvanMurzak.Unity.MCP.Animation.Editor.Tests
 {


### PR DESCRIPTION
## Summary

Unity-MCP 0.68.0 renamed the data-model namespace `com.IvanMurzak.Unity.MCP.Runtime.Data` to `AIGD` and flattened nested tool data models (Unity-MCP PR #704). The release pipeline classified that change as `refactor:` (minor bump), but it is breaking for downstream extensions, so this package's post-DLL-refresh commit failed CI on `main`.

This PR replaces `using com.IvanMurzak.Unity.MCP.Runtime.Data;` with `using AIGD;` in all 8 source files that reference the old namespace.

### Files changed

- `Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.GetData.cs`
- `Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Modify.cs`
- `Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.GetData.cs`
- `Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Modify.cs`
- `Unity-Package/Assets/root/Tests/Editor/AnimationGetData_Tests.cs`
- `Unity-Package/Assets/root/Tests/Editor/AnimationModify_Tests.cs`
- `Unity-Package/Assets/root/Tests/Editor/AnimatorGetData_Tests.cs`
- `Unity-Package/Assets/root/Tests/Editor/AnimatorModify_Tests.cs`

### CS0006 (stale DLL paths)

The failing CI log also showed:
```
error CS0006: Metadata file 'Assets/Plugins/NuGet/com.IvanMurzak.McpPlugin.6.1.0/McpPlugin.dll' could not be found
error CS0006: Metadata file 'Assets/Plugins/NuGet/com.IvanMurzak.McpPlugin.Common.6.1.0/McpPlugin.Common.dll' could not be found
error CS0006: Metadata file 'Assets/Plugins/NuGet/com.IvanMurzak.ReflectorNet.5.0.0/ReflectorNet.dll' could not be found
```

These are downstream effects of CS0234. The on-disk DLLs are 6.1.2 / 5.1.1, and `grep` finds no committed file that references the 6.1.0 / 5.0.0 paths. Unity caches stale auto-generated `.csproj` references when compilation fails early; with the namespace error resolved, Unity regenerates `.csproj` from the real on-disk DLLs and CS0006 should disappear.

## Test plan

- [ ] CI green on `release.yml` (6 editmode + 6 standalone + 6 playmode jobs across Unity 2022.3.62f3, 2023.2.22f1, 6000.3.1f1)
- [ ] No CS0006 / CS0234 / CS0246 errors in any matrix job