### PR TITLE
feat(skills): add SkillDescription/SkillBody to Animation tools

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Create.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Create.cs
@@ -34,6 +34,19 @@ namespace com.IvanMurzak.Unity.MCP.Animation
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Create empty Unity `AnimationClip` assets at the given project paths. Each path " +
+            "must start with `Assets/` and end with `.anim`. Missing intermediate folders are created recursively. " +
+            "Pair with '" + AnimationModifyToolId + "' to populate curves and events.")]
+        [McpPluginSkillBody("Create empty Unity `AnimationClip` assets at the given project paths. Each path must " +
+            "start with `Assets/` and end with `.anim`. Missing intermediate folders are created recursively, " +
+            "then `AssetDatabase.Refresh()` runs and the Editor windows repaint. Pair with " +
+            "'" + AnimationModifyToolId + "' to populate curves and events afterwards.\n\n" +
+            "## Inputs\n\n" +
+            "- `sourcePaths` — array of project-relative `.anim` paths to create.\n\n" +
+            "## Behavior\n\n" +
+            "Each path is validated independently: empty / non-`Assets/` / non-`.anim` paths are skipped and " +
+            "appended to `errors` instead of aborting the whole batch. Successfully created clips are returned in " +
+            "`createdAssets` with their path, instance ID, and name.")]
         [Description(@"Create Unity's Animation asset files (AnimationClip). Creates folders recursively if they do not exist. Each path should start with 'Assets/' and end with '.anim'.")]
         public static CreateAnimationResponse CreateAnimationClips
         (

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.GetData.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.GetData.cs
@@ -34,6 +34,24 @@ namespace com.IvanMurzak.Unity.MCP.Animation
             IdempotentHint = true,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Inspect a Unity `AnimationClip` asset — name, length, frame rate, wrap mode, " +
+            "looping/legacy/humanMotion flags, local bounds, and the full set of float curves, object-reference " +
+            "curves, and events. Pair with '" + AnimationModifyToolId + "' to write changes back.")]
+        [McpPluginSkillBody("Inspect a Unity `AnimationClip` asset. Returns the high-level clip metadata plus the " +
+            "complete set of float curve bindings, object-reference curve bindings, and animation events. Pair " +
+            "with '" + AnimationModifyToolId + "' to write changes back.\n\n" +
+            "## Inputs\n\n" +
+            "- `animRef` — reference to the `AnimationClip` asset (path must start with `Assets/` and end with " +
+            "`.anim`).\n\n" +
+            "## Returned fields\n\n" +
+            "- `name`, `length`, `frameRate`, `wrapMode`, `isLooping`, `hasGenericRootTransform`, " +
+            "`hasMotionCurves`, `hasMotionFloatCurves`, `hasRootCurves`, `humanMotion`, `legacy`, `localBounds`, " +
+            "`empty`.\n" +
+            "- `curveBindings` — float curve bindings (`path`, `propertyName`, `type`, `isPPtrCurve`, " +
+            "`isDiscreteCurve`, `keyframeCount`).\n" +
+            "- `objectReferenceBindings` — object-reference curve bindings (same shape as `curveBindings`).\n" +
+            "- `events` — animation events (`time`, `functionName`, `intParameter`, `floatParameter`, " +
+            "`stringParameter`).")]
         [Description(@"Get data about a Unity AnimationClip asset file. Returns information such as name, length, frame rate, wrap mode, animation curves, and events.")]
         public static GetDataResponse GetData
         (

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animation.Modify.cs
@@ -35,6 +35,29 @@ namespace com.IvanMurzak.Unity.MCP.Animation
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Apply a batch of modifications to a Unity `AnimationClip` — set/remove float " +
+            "curves, clear all curves, set frame rate / wrap mode / legacy flag, add or clear animation events. " +
+            "Use '" + AnimationGetDataToolId + "' first to discover valid curve bindings.")]
+        [McpPluginSkillBody("Apply a batch of modifications to a Unity `AnimationClip` asset. Each modification " +
+            "is dispatched by its `ModificationType` discriminator. Use '" + AnimationGetDataToolId + "' first " +
+            "to discover valid property names and existing curves so the diff is targeted.\n\n" +
+            "## Inputs\n\n" +
+            "- `animRef` — reference to the `AnimationClip` asset (path must start with `Assets/` and end with " +
+            "`.anim`).\n" +
+            "- `modifications` — array of `AnimationModification` entries.\n\n" +
+            "## Supported modification types\n\n" +
+            "- `SetCurve` — add or replace a float animation curve (`path`, `propertyName`, `type`, `keyframes`).\n" +
+            "- `RemoveCurve` — remove a specific binding.\n" +
+            "- `ClearCurves` — remove every curve from the clip.\n" +
+            "- `SetFrameRate` — set the clip's frame rate.\n" +
+            "- `SetWrapMode` — set the clip's `WrapMode`.\n" +
+            "- `SetLegacy` — toggle the legacy animation flag.\n" +
+            "- `AddEvent` — append an animation event (`time`, `functionName`, `intParameter`, `floatParameter`, " +
+            "`stringParameter`).\n" +
+            "- `ClearEvents` — remove every animation event.\n\n" +
+            "## Behavior\n\n" +
+            "Per-modification errors are accumulated in the response's `errors` array instead of aborting the " +
+            "whole batch. Events are applied as a single rewrite after all per-entry mutations finish.")]
         [Description("Modify Unity's AnimationClip asset. " +
             "Apply an array of modifications including setting curves, clearing curves, setting properties, and managing animation events. " +
             "Use '" + AnimationGetDataToolId + "' tool to get valid property names and existing curves for modifications.")]

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Create.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Create.cs
@@ -34,6 +34,19 @@ namespace com.IvanMurzak.Unity.MCP.Animation
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Create empty Unity `AnimatorController` assets at the given project paths. " +
+            "Each path must start with `Assets/` and end with `.controller`. Missing intermediate folders are " +
+            "created recursively. Pair with '" + AnimatorModifyToolId + "' to add layers/states/parameters.")]
+        [McpPluginSkillBody("Create empty Unity `AnimatorController` assets at the given project paths. Each path " +
+            "must start with `Assets/` and end with `.controller`. Missing intermediate folders are created " +
+            "recursively, then `AssetDatabase.Refresh()` runs and the Editor windows repaint. Pair with " +
+            "'" + AnimatorModifyToolId + "' to add layers, states, parameters, and transitions afterwards.\n\n" +
+            "## Inputs\n\n" +
+            "- `sourcePaths` — array of project-relative `.controller` paths to create.\n\n" +
+            "## Behavior\n\n" +
+            "Each path is validated independently: empty / non-`Assets/` / non-`.controller` paths are skipped " +
+            "and appended to `errors` instead of aborting the whole batch. Successfully created controllers are " +
+            "returned in `createdAssets` with their path, instance ID, and name.")]
         [Description(@"Create Unity's AnimatorController asset files. Creates folders recursively if they do not exist. Each path should start with 'Assets/' and end with '.controller'.")]
         public static CreateAnimatorResponse CreateAnimatorControllers
         (

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.GetData.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.GetData.cs
@@ -33,6 +33,21 @@ namespace com.IvanMurzak.Unity.MCP.Animation
             IdempotentHint = true,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Inspect a Unity `AnimatorController` asset — controller name, every parameter " +
+            "(name, type, defaults), every layer with its state machine, every state, and every transition. Pair " +
+            "with '" + AnimatorModifyToolId + "' to write changes back.")]
+        [McpPluginSkillBody("Inspect a Unity `AnimatorController` asset. Returns the controller's name plus the " +
+            "full set of parameters, layers, states, and transitions — enough to drive a follow-up " +
+            "'" + AnimatorModifyToolId + "' call with valid names.\n\n" +
+            "## Inputs\n\n" +
+            "- `animatorRef` — reference to the `AnimatorController` asset (path must start with `Assets/` and " +
+            "end with `.controller`).\n\n" +
+            "## Returned fields\n\n" +
+            "- `name` — controller asset name.\n" +
+            "- `parameters` — every parameter (name, type, default value).\n" +
+            "- `layers` — every layer with its state machine, default state, and weight.\n" +
+            "- `states` — every state across all layers (name, speed, motion).\n" +
+            "- `transitions` — every transition with its conditions, source, and destination.")]
         [Description(@"Get data about a Unity AnimatorController asset file. Returns information such as name, layers, parameters, and states.")]
         public static GetAnimatorDataResponse GetData
         (

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/Animator.Modify.cs
@@ -37,6 +37,28 @@ namespace com.IvanMurzak.Unity.MCP.Animation
             IdempotentHint = false,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Apply a batch of modifications to a Unity `AnimatorController` — add/remove " +
+            "parameters, layers, states, and transitions; set default states; set state motion/speed. Use " +
+            "'" + AnimatorGetDataToolId + "' first to discover valid names.")]
+        [McpPluginSkillBody("Apply a batch of modifications to a Unity `AnimatorController` asset. Each " +
+            "modification is dispatched by its `AnimatorModificationType` discriminator. Use " +
+            "'" + AnimatorGetDataToolId + "' first to discover valid names so the diff is targeted.\n\n" +
+            "## Inputs\n\n" +
+            "- `animatorRef` — reference to the `AnimatorController` asset (path must start with `Assets/` and " +
+            "end with `.controller`).\n" +
+            "- `modifications` — array of `AnimatorModification` entries.\n\n" +
+            "## Supported modification types\n\n" +
+            "- `AddParameter` / `RemoveParameter` — manage controller parameters (float, int, bool, trigger).\n" +
+            "- `AddLayer` / `RemoveLayer` — manage animator layers.\n" +
+            "- `AddState` / `RemoveState` — manage states inside a specific layer.\n" +
+            "- `SetDefaultState` — pick the default state for a layer.\n" +
+            "- `AddTransition` / `RemoveTransition` — manage state-to-state transitions.\n" +
+            "- `AddAnyStateTransition` — add a transition from Any State.\n" +
+            "- `SetStateMotion` — assign an `AnimationClip` as a state's motion.\n" +
+            "- `SetStateSpeed` — set a state's speed multiplier.\n\n" +
+            "## Behavior\n\n" +
+            "Per-modification errors are accumulated in the response's `errors` array instead of aborting the " +
+            "whole batch. The controller asset is marked dirty and saved after the modifications complete.")]
         [Description("Modify Unity's AnimatorController asset. " +
             "Apply an array of modifications including adding/removing parameters, layers, states, and transitions. " +
             "Use '" + AnimatorGetDataToolId + "' tool to get valid names and parameters for modifications.")]

--- a/Unity-Package/Assets/root/package.json
+++ b/Unity-Package/Assets/root/package.json
@@ -16,7 +16,7 @@
     "unity": "2022.3",
     "description": "MCP Tools for Animation - Enhance your Unity projects with AI-powered Animation tools using the MCP framework.",
     "dependencies": {
-        "com.ivanmurzak.unity.mcp": "0.72.1",
+        "com.ivanmurzak.unity.mcp": "0.72.2",
         "com.unity.modules.animation": "1.0.0"
     },
     "scopedRegistries": [

--- a/Unity-Package/Packages/manifest.json
+++ b/Unity-Package/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ivanmurzak.unity.mcp": "0.72.1",
+    "com.ivanmurzak.unity.mcp": "0.72.2",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",


### PR DESCRIPTION
## Summary

Follow-on to Unity-MCP [PR #758](https://github.com/IvanMurzak/Unity-MCP/pull/758) — extends the `[McpPluginSkillDescription]` / `[McpPluginSkillBody]` coverage from the core Unity-MCP plugin to this extension. All six tool methods exposed by this package now carry both attributes.

## Changes

- Bumped `com.ivanmurzak.unity.mcp` dependency from `0.72.1` → `0.72.2` in `Unity-Package/Assets/root/package.json` and `Unity-Package/Packages/manifest.json`. The new attributes were introduced in `0.72.2`.
- Decorated each tool with `[McpPluginSkillDescription]` (concise summary suitable for the SKILL.md YAML front-matter, well under the 1024-char cap) and `[McpPluginSkillBody]` (long-form markdown with `## Inputs`, `## Behavior` / `## Returned fields` / `## Supported modification types` sections as appropriate):
  - `Animation.Create.cs` — `animation-create`
  - `Animation.GetData.cs` — `animation-get-data`
  - `Animation.Modify.cs` — `animation-modify`
  - `Animator.Create.cs` — `animator-create`
  - `Animator.GetData.cs` — `animator-get-data`
  - `Animator.Modify.cs` — `animator-modify`
- `[Description]` payloads are left **byte-identical** to `main`, so the MCP `tools/list` wire response is unchanged.

## Out of scope

- The generated `Unity-Package/.claude/skills/animation-*` and `animator-*/SKILL.md` files are intentionally left untouched in this PR. They should be regenerated by running the `unity-skill-generate` MCP tool inside Unity and committed as a follow-up (same round-trip pattern as Unity-MCP PR #758 commit `57334844`).

## Verification

- Static review confirms both new attributes are correctly applied to every `[McpPluginTool]` method and the `[Description]` strings are byte-identical to `main`.
- A reviewer with Unity open should run `unity-skill-generate` to confirm the regenerated SKILL.md files include the new `description:` YAML field and body markdown.

Refs IvanMurzak/Unity-MCP#729, IvanMurzak/Unity-MCP#758

🤖 Generated with [Claude Code](https://claude.com/claude-code)