### PR TITLE
Release: Unity-MCP 0.82.3 cascade

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Animation Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Animation Installer/Installer.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Animation.Installer
     public static partial class Installer
     {
         public const string PackageId = "com.ivanmurzak.unity.mcp.animation";
-        public const string Version = "1.2.22";
+        public const string Version = "1.2.23";
 
         static Installer()
         {

--- a/Unity-Package/Packages/com.ivanmurzak.unity.mcp.animation/package.json
+++ b/Unity-Package/Packages/com.ivanmurzak.unity.mcp.animation/package.json
@@ -12,11 +12,11 @@
         "MCP",
         "Unity MCP"
     ],
-    "version": "1.2.22",
+    "version": "1.2.23",
     "unity": "2022.3",
     "description": "MCP Tools for Animation - Enhance your Unity projects with AI-powered Animation tools using the MCP framework.",
     "dependencies": {
-        "com.ivanmurzak.unity.mcp": "0.82.2",
+        "com.ivanmurzak.unity.mcp": "0.82.3",
         "com.unity.modules.animation": "1.0.0"
     },
     "scopedRegistries": [

--- a/Unity-Package/Packages/packages-lock.json
+++ b/Unity-Package/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ivanmurzak.unity.mcp": {
-      "version": "0.82.2",
+      "version": "0.82.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Automated release cascade for [Unity-MCP 0.82.3](https://github.com/IvanMurzak/Unity-MCP/releases/tag/0.82.3).

- Bumps the `com.ivanmurzak.unity.mcp` dependency to `0.82.3`.
- Patch-bumps this extension's own version (skipped for Unity-AI-Tools-Template).
- When the release changed bundled NuGet DLLs: refreshes `Assets/Plugins/NuGet/` drops and per-Unity-version `.meta` files across Unity-Package and Unity-Tests projects.

Merge only after every check is green (enforced by the branch ruleset). Opened by the unity-mcp/plugin release pipeline (iteration 03b).