### PR TITLE
chore(ci): retire redundant PackageCache band-aid step

### DIFF
--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -98,27 +98,6 @@ jobs:
           key: ${{ inputs.unityVersion }} ${{ inputs.testMode }} on ${{ matrix.platform }}
 
       # --------------------------------------------------------------------- #
-      # Strip stale com.ivanmurzak.unity.mcp* entries from Library/PackageCache.
-      # The cache restore above can resurrect a PackageCache directory from a
-      # run where com.ivanmurzak.unity.mcp was pinned to an older version. When
-      # Unity then resolves the currently pinned version (per package.json) on
-      # top, BOTH directories appear under Library/PackageCache and the Package
-      # Manager registers BOTH as installed. The fresh version's source uses
-      # [AiPrompt*] types that only exist in the fresh DLLs, but the loader's
-      # class-table is contaminated by the stale assemblies, producing CS0246
-      # at compile time. Forcing a clean re-resolve every run resolves this.
-      - name: Strip stale com.ivanmurzak.unity.mcp PackageCache entries
-        shell: bash
-        run: |
-          cache_dir="${{ inputs.projectPath }}/Library/PackageCache"
-          if [ -d "$cache_dir" ]; then
-            echo "Cache dir exists. Checking for stale com.ivanmurzak.unity.mcp* entries:"
-            find "$cache_dir" -maxdepth 1 -type d -name 'com.ivanmurzak.unity.mcp*' -print -exec rm -rf {} +
-          else
-            echo "Cache dir $cache_dir not present — nothing to clean."
-          fi
-
-      # --------------------------------------------------------------------- #
       - name: Generate custom image name
         id: custom_image
         run: echo "image=unityci/editor:ubuntu-${{ inputs.unityVersion }}-${{ matrix.platform }}-3" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Removes the redundant `Strip stale com.ivanmurzak.unity.mcp PackageCache entries` CI step (and its explanatory comment block) from `.github/workflows/test_unity_plugin.yml`.

This `rm -rf` step existed to **mask** version skew — between the extension's core pin, the `packages-lock.json` files, and the vendored NuGet DLLs — by force-clearing stale `Library/PackageCache/com.ivanmurzak.unity.mcp*` entries on every run. That skew is now caught **directly** by the `version-consistency` job (added in f1 of the `unity-extensions-maintain` work), which turns skew into a RED build instead of silently papering over it. The fleet has been reconciled, so no band-aid interventions are needed.

Everything else is left intact — the `actions/cache@v5` restore step above it, the `version-consistency` job (f1), and all Unity test steps. Pure single-step deletion, no other lines changed.

## Rollback

To restore, re-add the `Strip stale com.ivanmurzak.unity.mcp PackageCache entries` step after the `actions/cache` restore step — a single-step re-add per repo.

---

Design task **f2** (band-aid retirement) of `unity-extensions-maintain`.
