### PR TITLE
chore: gitignore pipeline runtime state (.pipeline/.runtime, .pipeline/.stats)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 # Claude
 .claude
+
+# Machine-generated pipeline runtime state — not source.
+# `.pipeline/.hooks/` stays tracked; only its runtime siblings are ignored.
+.pipeline/.runtime/
+.pipeline/.stats/


### PR DESCRIPTION
## Problem

The `ai-pipeline` plugin writes machine-generated runtime state into
`<repo>/.pipeline/.runtime/` (an `events.jsonl` plus transcript `.offset` files)
in whatever repo it runs in. Because that state is untracked and unignored, it
shows up as **repo dirt** — which in turn blocks the `--parallel>1` main-checkout
cleanliness gate in our orchestration tooling.

## Fix

Ignore the two machine-generated siblings, mirroring the pattern already in the
`software` superproject root `.gitignore`:

```
.pipeline/.runtime/
.pipeline/.stats/
```

Note this deliberately ignores the **siblings only**, *not* the whole
`.pipeline/` directory: `.pipeline/.hooks/` is tracked on purpose (the pipeline
plugin resolves the consumer's worktree hooks from `<root>/.pipeline/.hooks`),
so it must stay trackable here if this repo ever gains real pipeline hooks.

## Verification

`git check-ignore -v` against the new lines:

| Path | Result |
|---|---|
| `.pipeline/.runtime/events.jsonl` | ignored — matches `.pipeline/.runtime/` |
| `.pipeline/.stats/foo.json` | ignored — matches `.pipeline/.stats/` |
| `.pipeline/.hooks/worktree-create.py` | **NOT ignored** (exit 1) — the regression this pattern exists to avoid |

Also confirmed against real files on disk: with all four paths materialised,
`git status --porcelain -uall` lists **only** `.pipeline/.hooks/worktree-create.py`
as untracked; the runtime and stats files are invisible. Probe files removed
before committing.

No other content in `.gitignore` was reordered or reformatted.
