### PR TITLE
ci: release.yml hygiene — job timeouts + release concurrency (queue)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,24 @@ on:
     branches:
       - main
 
+# Serialises release runs per ref so two releases can never publish concurrently.
+# `cancel-in-progress` is deliberately UNSET: an in-flight release must finish
+# (it may already have created the tag/Release). `queue: max` raises the pending
+# queue from the default 1 to 100 — without it, a queued release is silently
+# cancelled and replaced by the next push, which is how a version bump can be
+# published while an earlier one never runs.
+# NOTE: `queue: max` and `cancel-in-progress: true` together are a validation error.
+concurrency:
+  group: release-${{ github.ref }}
+  queue: max
+
 env:
   INSTALLER_UNITY_VERSION: 2022.3.62f3
 
 jobs:
   check-version-tag:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.get_version.outputs.current-version }}
       prev_tag: ${{ steps.prev_tag.outputs.tag }}
@@ -43,6 +55,7 @@ jobs:
   # The artifact is consumed by release-unity-plugin's atomic publish step.
   prepare-release-notes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [check-version-tag]
     if: needs.check-version-tag.outputs.tag_exists == 'false'
     steps:
@@ -100,6 +113,9 @@ jobs:
 
   build-unity-installer:
     runs-on: ubuntu-latest
+    # Unity-editor job (EditMode test + package export in the Unity image).
+    # Observed 4m29s-7m24s; generous headroom for image pull / licence activation.
+    timeout-minutes: 30
     needs: [check-version-tag]
     if: needs.check-version-tag.outputs.tag_exists == 'false'
     steps:
@@ -187,6 +203,7 @@ jobs:
   # See https://openupm.com/docs/signing-upm-packages.html for the procedure.
   build-signed-upm-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [check-version-tag]
     if: needs.check-version-tag.outputs.tag_exists == 'false'
     env:
@@ -363,6 +380,7 @@ jobs:
   # release with incomplete assets. Signing failure → no release (hard gate).
   release-unity-plugin:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       [
         check-version-tag,
@@ -430,6 +448,7 @@ jobs:
   # post-release publish job collapsed into release-unity-plugin.
   cleanup-artifacts:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [release-unity-plugin]
     if: always()
     steps:


### PR DESCRIPTION
Adds two runaway guards to `release.yml`. Hygiene attributes only — no rename, no restructuring, no version files, gate topology untouched.

## 1. Job timeouts

Every job previously inherited the **6-hour** GitHub default. Derived from the **5 most recent successful full release runs** (`30354826261`, `30201966471`, `29762726136`, `29757793994`, `29704719893`) — a hung job could previously burn 6h of Actions time before anyone noticed.

Rule applied: **~2× observed p95, floor of 10 minutes**, generous for the Unity-editor job. With n=5, p95 ≈ observed max.

| Job | Observed durations (5 runs) | p95 ≈ max | 2× p95 | **Chosen** | Headroom vs worst |
|---|---|---|---|---|---|
| `check-version-tag` | 9s, 20s, 12s, 19s, 8s | 20s | 40s | **10 min** (floor) | 30× |
| `prepare-release-notes` | 9s, 8s, 10s, 12s, 9s | 12s | 24s | **10 min** (floor) | 50× |
| `build-signed-upm-package` | 13s, 10s, 9s, 8s, 10s | 13s | 26s | **10 min** (floor) | 46× |
| `build-unity-installer` | 4m29s, 4m42s, 4m48s, 4m57s, **7m24s** | 7m24s | ~15 min | **30 min** (Unity-editor, generous) | 4.1× |
| `release-unity-plugin` | 15s, 18s, 13s, 11s, 5s | 18s | 36s | **10 min** (floor) | 33× |
| `cleanup-artifacts` | 8s, 4s, 5s, 6s, 6s | 8s | 16s | **10 min** (floor) | 75× |

`build-unity-installer` runs a Unity EditMode test **and** a package export inside the Unity image, so its variance is dominated by image pull and licence activation rather than by our code — hence 30 min rather than the arithmetic ~15.

### The 9 `test-unity-*` jobs deliberately have NO timeout — it is not expressible here

These call a reusable workflow (`uses: ./.github/workflows/test_unity_plugin.yml`). `timeout-minutes` is **not a permitted key** on a reusable-workflow-calling job, and adding it is a **hard validation error** (`The workflow is not valid ... Unexpected value 'timeout-minutes'`) that fails the entire workflow file — every job, including the PR run. Verified three independent ways:

1. **GitHub docs, closed allowlist** — [Reusing workflow configurations](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations): *"When you call a reusable workflow, you can only use the following keywords in the job containing the call"* → `name`, `uses`, `with`, `with.<input_id>`, `secrets`, `secrets.<secret_id>`, `secrets.inherit`, `strategy`, `needs`, `if`, `concurrency`, `permissions`. `timeout-minutes` is absent.
2. **GitHub's own parser schema** — [`workflow-v1.0.json`](https://raw.githubusercontent.com/actions/languageservices/main/workflow-parser/src/workflow-v1.0.json): the `workflow-job` mapping declares no `timeout-minutes`, while the ordinary `job-factory` does.
3. **actionlint v1.7.12**, run locally against a probe file:
   ```
   when a reusable workflow is called with "uses", "timeout-minutes" is not available.
   only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if", and "permissions"
   ```

**These are the longest jobs in the pipeline and remain unbounded** — observed up to **17m45s** (`2023.2.22f1 editmode on windows-mono`), with editmode legs routinely 11–17 min. Bounding them requires `timeout-minutes` on the jobs *inside* `test_unity_plugin.yml`, which is out of scope for this PR. Suggested follow-up, from the same 5 runs: editmode legs max 17m45s → ~45 min; playmode max 9m54s → ~30 min; standalone max 7m12s → ~30 min; `version-consistency` max 10s → 10 min.

## 2. Release concurrency

```yaml
concurrency:
  group: release-${{ github.ref }}
  queue: max
```

`cancel-in-progress` is **deliberately unset** — an in-flight release must finish, since it may already have created the tag and GitHub Release.

`queue: max` is the load-bearing part. The documented default (`queue: single`) keeps at most **one** pending run and **silently cancels and replaces it** when another is queued — so back-to-back version bumps could see an earlier bump's release cancelled while never having run.

### Queue syntax — doc citation

Verified against official sources before authoring:

- [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) — *"To allow more than one `pending` job or workflow run to wait in the same concurrency group, use the optional `queue` property."* Values: *"`single` (default): At most one job or workflow run can be `pending` in the concurrency group. When a new job or workflow run is queued, any existing `pending` job or workflow run in the same group is canceled and replaced. `max`: Up to 100 jobs or workflow runs can be `pending` in the concurrency group."* The page's own example is workflow-level and uses `queue: max` verbatim.
- [Control the concurrency of workflows and jobs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)
- [Changelog: GitHub Actions concurrency groups now allow larger queues (2026-05-07)](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/)

Also documented and respected here: *"The combination of `queue: max` and `cancel-in-progress: true` is not allowed and will result in a workflow validation error."* Leaving `cancel-in-progress` unset is required, not stylistic. Queue order is FIFO; overflow past 100 pending is cancelled.

> ⚠️ **actionlint flags `queue` as an unknown key — this is expected linter staleness, not a defect.** The newest actionlint release is v1.7.12 (2026-03-30), which predates the `queue` feature (2026-05-07), so **no** actionlint version can validate it. The remaining actionlint output on this file is that single line and nothing else. GitHub's own parser is the authority here.

## Validation performed

- `actionlint v1.7.12` on the modified file → **only** the known-stale `queue` line; clean baseline on the unmodified file beforehand.
- Independent `yaml.safe_load` parse → 15 jobs; the 6 `steps` jobs carry timeouts, the 9 `uses` jobs carry none.
- Diff is **+19 / −0**.

## Constraints honoured

- ✅ File **not** renamed (NuGet Trusted Publishing matches by workflow file name).
- ✅ No `permissions:` block added anywhere — the workflow had none and relies on default token permissions, so `release-unity-plugin` keeps its `contents: write` capability untouched. Per the task constraint, when in doubt permissions were not touched.
- ✅ Gate topology untouched: `check-version-tag` → tests → atomic all-tests-gated publish. No `needs:` array and no `if:` condition was modified.
- ✅ No version files touched — nothing releases from this PR.

The full 27-job PR matrix firing on this PR is expected and one-off.
